### PR TITLE
Add minimal Prometheus support

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps="sudo build-essential libc-dev ruby-dev" \
  && gem install fluent-plugin-kafka \
  && gem install fluent-plugin-remote_syslog \
  && gem install fluent-plugin-rewrite-tag-filter \
+ && gem install fluent-plugin-prometheus \
  && gem install zookeeper \
  && sudo gem sources --clear-all \
  && SUDO_FORCE_REMOVE=yes \
@@ -25,10 +26,12 @@ ENV FLUENTD_CONF="fluent.conf"
 RUN mkdir -p /fluentd/etc/buffer
 RUN mkdir -p /fluentd/etc/config/custom/cluster/
 RUN mkdir -p /fluentd/etc/config/custom/project/
+RUN mkdir -p /fluentd/etc/config/system/
 
 COPY fluent.conf /fluentd/etc/
 COPY custom_cluster.conf /fluentd/etc/config/custom/
 COPY custom_project.conf /fluentd/etc/config/custom/
+COPY metrics.conf /fluentd/etc/config/system/
 
 EXPOSE 24224 5140
 

--- a/package/fluent.conf
+++ b/package/fluent.conf
@@ -5,6 +5,7 @@
 
 @include /fluentd/etc/config/custom/custom_cluster.conf
 @include /fluentd/etc/config/custom/custom_project.conf
+@include /fluentd/etc/config/system/metrics.conf
 @include /fluentd/etc/config/custom/project/*.conf
 @include /fluentd/etc/config/custom/cluster/*.conf
 

--- a/package/metrics.conf
+++ b/package/metrics.conf
@@ -1,0 +1,15 @@
+
+<source>
+  @type prometheus
+  bind 0.0.0.0
+  port 24231
+  metrics_path /metrics
+</source>
+
+<source>
+  @type prometheus_output_monitor
+  interval 10
+  <labels>
+    pod_name ${hostname}
+  </labels>
+</source>


### PR DESCRIPTION
This enables barebones support for Prometheus metrics. At a minimum, we should be able to start monitoring some of the basic stats and health of Fluentd.