### PR TITLE
fix fluentd kubernetes plugin to version 2.0.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,7 +6,7 @@ RUN buildDeps="sudo build-essential libc-dev ruby-dev" \
  && apt-get install -y --no-install-recommends $buildDeps \
  && sudo gem install fluent-plugin-elasticsearch \
  && gem install fluent-plugin-secure-forward \
- && gem install fluent-plugin-kubernetes_metadata_filter \
+ && gem install fluent-plugin-kubernetes_metadata_filter -v 2.0.0 \
  && gem install fluent-plugin-splunk-enterprise \
  && gem install fluent-plugin-kafka \
  && gem install fluent-plugin-remote_syslog_tls \ 


### PR DESCRIPTION
Bugfix for Rancher issue [#15880](https://github.com/rancher/rancher/issues/15880)
The config tags merge_json_log and preserve_json_log are no longer supported.
This leads to unparsed JSON logs.
Downgrading from version 2.1.0 to 2.0.0 will fix this issue.