### PR TITLE
upgrade fluentd gem version to support client cert

### DIFF
--- a/package/Gemfile
+++ b/package/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fluentd', '~>1.3.1'
+gem 'fluentd', '~>1.3.3'
 
 # Input / Output plugins:
 gem 'fluent-plugin-elasticsearch', '~>2.12.3'

--- a/package/Gemfile.lock
+++ b/package/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     concurrent-ruby (1.1.4)
     cool.io (1.5.3)
@@ -31,7 +31,7 @@ GEM
       elasticsearch
       excon
       fluentd (>= 0.14.20)
-    fluent-plugin-kafka (0.8.3)
+    fluent-plugin-kafka (0.8.4)
       fluentd (>= 0.10.58, < 2)
       ltsv
       ruby-kafka (>= 0.7.1, < 0.8.0)
@@ -52,7 +52,7 @@ GEM
       fluentd (>= 0.12.0)
       httpclient
       json
-    fluentd (1.3.2)
+    fluentd (1.3.3)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -73,9 +73,9 @@ GEM
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.3.0)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
-    json (2.1.0)
+    json (2.2.0)
     kubeclient (1.1.4)
       activesupport
       http (= 0.9.8)
@@ -87,12 +87,11 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     minitest (5.11.3)
-    msgpack (1.2.4)
+    msgpack (1.2.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
-    oj (3.7.4)
-    prometheus-client (0.8.0)
+    prometheus-client (0.9.0)
       quantile (~> 0.2.1)
     public_suffix (3.0.3)
     quantile (0.2.1)
@@ -103,7 +102,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    ruby-kafka (0.7.4)
+    ruby-kafka (0.7.5)
       digest-crc
     serverengine (2.1.0)
       sigdump (~> 0.2.2)
@@ -113,7 +112,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.7)
+    tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -125,7 +124,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 5.2.2)
   fluent-plugin-elasticsearch (~> 2.12.3)
   fluent-plugin-kafka (~> 0.8.1)
   fluent-plugin-kubernetes_metadata_filter (~> 2.0.0)
@@ -133,6 +131,5 @@ DEPENDENCIES
   fluent-plugin-remote_syslog_tls (~> 1.0.2)
   fluent-plugin-rewrite-tag-filter (~> 2.1.1)
   fluent-plugin-splunk-enterprise (~> 0.9.1)
-  fluentd (~> 1.3.1)
-  oj (~> 3.7.4)
+  fluentd (~> 1.3.3)
   zookeeper (~> 1.4.11)


### PR DESCRIPTION
problem:
before fluentd 1.3.1 version can't support add client cert for fluentd output

Solution:
upgrade fluentd to 1.3.3, but the related kafka gem also upgrade small
version, tested fluentd and kafka after upgrade version

Issue:
https://github.com/rancher/rancher/issues/18396