### PR TITLE
Update default fluentd configure to avoid deprecated configure warning

### DIFF
--- a/package/fluent.conf
+++ b/package/fluent.conf
@@ -1,8 +1,10 @@
 # This is the root config file, which only includes components of the actual configuration
 
 # Do not collect fluentd's own logs to avoid infinite loops.
-<match fluent.**>
-  @type null
-</match>
+<label @FLUENT_LOG>
+  <match fluent.*>
+    @type null
+  </match>
+</label>
 
 @include /etc/fluent/config.d/*.conf

--- a/package/windows/fluent.conf
+++ b/package/windows/fluent.conf
@@ -1,8 +1,10 @@
 # This is the root config file, which only includes components of the actual configuration
 
 # Do not collect fluentd's own logs to avoid infinite loops.
-<match fluent.**>
-  @type null
-</match>
+<label @FLUENT_LOG>
+  <match fluent.*>
+    @type null
+  </match>
+</label>
 
 @include /etc/fluent/config.d/*.conf


### PR DESCRIPTION
Problem:
Fluentd-tester which use this default configure, when click dry-run in the UI will get deprecated configure warning

Solution:
Upate configure to latest format.

Issue:
https://github.com/rancher/rancher/issues/26543