### PR TITLE
Update default fluentd configure to avoid duplicated FLUENT_LOG configuration

### DIFF
--- a/package/fluent.conf
+++ b/package/fluent.conf
@@ -1,10 +1,8 @@
 # This is the root config file, which only includes components of the actual configuration
 
 # Do not collect fluentd's own logs to avoid infinite loops.
-<label @FLUENT_LOG>
-  <match fluent.*>
-    @type null
-  </match>
-</label>
+<match **.**>
+  @type null
+</match>
 
 @include /etc/fluent/config.d/*.conf


### PR DESCRIPTION
Problem:
We already add label in rancher FLUENT_LOG, if we also add FLUENT_LOG here will get duplicated configuration error.

Solution:
Remove FLUENT_LOG label.

Issue:
https://github.com/rancher/rancher/issues/26543