### PR TITLE
Upgrade metadata filter

### DIFF
--- a/package/Gemfile
+++ b/package/Gemfile
@@ -6,7 +6,7 @@ gem 'json', '2.3.0'
 
 gem 'fluentd', '1.8.0'
 
-gem 'fluent-plugin-elasticsearch', '7.4.0'
+gem 'fluent-plugin-elasticsearch', '3.8.0'
 gem 'fluent-plugin-prometheus', '1.7.0'
 gem 'fluent-plugin-splunk-enterprise', '0.10.0'
 gem 'fluent-plugin-kafka', '0.12.1'

--- a/package/Gemfile
+++ b/package/Gemfile
@@ -1,23 +1,21 @@
 source 'https://rubygems.org'
 
-gem 'cool.io'
-gem 'oj'
-gem 'json'
+gem 'cool.io', '1.5.4'
+gem 'oj', '3.10.0'
+gem 'json', '2.3.0'
 
-gem 'fluentd'
+gem 'fluentd', '1.8.0'
 
-# Input / Output plugins:
-gem 'fluent-plugin-elasticsearch'
-gem 'fluent-plugin-prometheus'
-gem 'fluent-plugin-splunk-enterprise'
-gem 'fluent-plugin-kafka'
-gem 'fluent-plugin-kubernetes_metadata_filter'
-gem 'fluent-plugin-remote_syslog_tls'
+gem 'fluent-plugin-elasticsearch', '7.4.0'
+gem 'fluent-plugin-prometheus', '1.7.0'
+gem 'fluent-plugin-splunk-enterprise', '0.10.0'
+gem 'fluent-plugin-kafka', '0.12.1'
+gem 'fluent-plugin-kubernetes_metadata_filter', '~>2.5.0'
+gem 'fluent-plugin-remote_syslog_tls', '1.0.2'
 
 # filter plugins
-gem 'fluent-plugin-concat'
-gem 'fluent-plugin-rewrite-tag-filter'
-gem 'fluent-plugin-multi-format-parser'
+gem 'fluent-plugin-concat', '2.4.0'
+gem 'fluent-plugin-rewrite-tag-filter', '2.2.0'
+gem 'fluent-plugin-multi-format-parser', '1.0.0'
 
-# third party
-gem 'zookeeper'
+gem 'zookeeper', '1.4.11'

--- a/package/Gemfile.lock
+++ b/package/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     excon (0.71.1)
     faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.3)
+    ffi (1.14.0)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -36,8 +36,8 @@ GEM
       fluentd (>= 0.10.58, < 2)
       ltsv
       ruby-kafka (>= 0.7.8, < 0.8.0)
-    fluent-plugin-kubernetes_metadata_filter (2.4.1)
-      fluentd (>= 0.14.0, < 2)
+    fluent-plugin-kubernetes_metadata_filter (2.5.2)
+      fluentd (>= 0.14.0, < 1.12)
       kubeclient (< 5)
       lru_redux
     fluent-plugin-multi-format-parser (1.0.0)
@@ -66,29 +66,33 @@ GEM
       tzinfo (>= 1.0, < 3.0)
       tzinfo-data (~> 1.0)
       yajl-ruby (~> 1.0)
-    http (4.2.0)
+    http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
-      http-form_data (~> 2.0)
+      http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (2.1.1)
-    http-parser (1.2.1)
-      ffi-compiler (>= 1.0, < 2.0)
+    http-form_data (2.3.0)
+    http-parser (1.2.2)
+      ffi-compiler
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
     json (2.3.0)
-    kubeclient (4.5.0)
+    jsonpath (1.0.5)
+      multi_json
+      to_regexp (~> 0.2.1)
+    kubeclient (4.9.1)
       http (>= 3.0, < 5.0)
-      recursive-open-struct (~> 1.0, >= 1.0.4)
+      jsonpath (~> 1.0)
+      recursive-open-struct (~> 1.1, >= 1.1.1)
       rest-client (~> 2.0)
     lru_redux (1.1.0)
     ltsv (0.1.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2020.1104)
     msgpack (1.3.1)
     multi_json (1.14.1)
     multipart-post (2.1.1)
@@ -96,10 +100,10 @@ GEM
     oj (3.10.0)
     prometheus-client (0.9.0)
       quantile (~> 0.2.1)
-    public_suffix (4.0.1)
+    public_suffix (4.0.6)
     quantile (0.2.1)
     rake (13.0.1)
-    recursive-open-struct (1.1.0)
+    recursive-open-struct (1.1.3)
     remote_syslog_sender_tls (1.2.5)
       syslog_protocol
     rest-client (2.1.0)
@@ -114,34 +118,36 @@ GEM
     sigdump (0.2.4)
     strptime (0.2.3)
     syslog_protocol (0.9.2)
+    to_regexp (0.2.1)
     tzinfo (2.0.0)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2019.3)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     yajl-ruby (1.4.1)
     zookeeper (1.4.11)
 
 PLATFORMS
   ruby
+  universal-darwin-18
 
 DEPENDENCIES
-  cool.io
-  fluent-plugin-concat
-  fluent-plugin-elasticsearch
-  fluent-plugin-kafka
-  fluent-plugin-kubernetes_metadata_filter
-  fluent-plugin-multi-format-parser
-  fluent-plugin-prometheus
-  fluent-plugin-remote_syslog_tls
-  fluent-plugin-rewrite-tag-filter
-  fluent-plugin-splunk-enterprise
-  fluentd
-  json
-  oj
-  zookeeper
+  cool.io (= 1.5.4)
+  fluent-plugin-concat (= 2.4.0)
+  fluent-plugin-elasticsearch (= 3.8.0)
+  fluent-plugin-kafka (= 0.12.1)
+  fluent-plugin-kubernetes_metadata_filter (~> 2.5.0)
+  fluent-plugin-multi-format-parser (= 1.0.0)
+  fluent-plugin-prometheus (= 1.7.0)
+  fluent-plugin-remote_syslog_tls (= 1.0.2)
+  fluent-plugin-rewrite-tag-filter (= 2.2.0)
+  fluent-plugin-splunk-enterprise (= 0.10.0)
+  fluentd (= 1.8.0)
+  json (= 2.3.0)
+  oj (= 3.10.0)
+  zookeeper (= 1.4.11)
 
 BUNDLED WITH
-   2.1.2
+   2.2.2


### PR DESCRIPTION
**Problem:**
Pods are restarting due to watch connections closing.

**Update:**
Update metadata filter to version that has logic to gracefully handle closed connections. This is the same fix as upstream:
https://github.com/fluent/fluentd-kubernetes-daemonset/issues/495

**Issue:**
https://github.com/rancher/rancher/issues/30425