### PR TITLE
remove 1903+1909, bump versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.5.4
+  image: rancher/dapper:v0.5.6
   commands:
   - dapper ci
   privileged: true
@@ -63,7 +63,7 @@ platform:
 steps:
   - name: build
     pull: always
-    image: rancher/dapper:v0.5.4
+    image: rancher/dapper:v0.5.6
     commands:
       - dapper.exe -f Dockerfile-windows.dapper -d ci
     volumes:
@@ -126,158 +126,6 @@ trigger:
   event:
     exclude:
       - promote
-
----
-kind: pipeline
-name: windows-1903
-
-platform:
-  os: windows
-  arch: amd64
-  version: 1903
-
-steps:
-- name: build
-  pull: always
-  image: rancher/dapper:v0.5.4
-  commands:
-  - dapper.exe -f Dockerfile-windows.dapper -d ci
-  volumes:
-  - name: docker_pipe
-    path: \\\\.\\pipe\\docker_engine
-  when:
-    event:
-    - push
-    - pull_request
-    - tag
-
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    build_args:
-    - SERVERCORE_VERSION=1903
-    - ARCH=amd64
-    - VERSION=${DRONE_TAG}
-    context: package/windows
-    custom_dns: 1.1.1.1
-    dockerfile: package/windows/Dockerfile
-    username:
-      from_secret: docker_username
-    password:
-      from_secret: docker_password
-    repo: rancher/fluentd
-    tag: ${DRONE_TAG}-windows-1903
-  volumes:
-  - name: docker_pipe
-    path: \\\\.\\pipe\\docker_engine
-  when:
-    event:
-    - tag
-    ref:
-    - refs/heads/master
-    - refs/tags/*
-
-- name: slack_notify
-  image: plugins/slack
-  settings:
-    template: "Build {{build.link}} failed to publish an image/artifact.\n"
-    username: Drone_Publish
-    webhook:
-      from_secret: slack_webhook
-  when:
-    event:
-      exclude:
-      - pull_request
-    instance:
-    - drone-publish.rancher.io
-    status:
-    - failure
-
-volumes:
-- name: docker_pipe
-  host:
-    path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-    - promote
-
----
-kind: pipeline
-name: windows-1909
-
-platform:
-  os: windows
-  arch: amd64
-  version: 1909
-
-steps:
-  - name: build
-    pull: always
-    image: rancher/dapper:v0.5.4
-    commands:
-      - dapper.exe -f Dockerfile-windows.dapper -d ci
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - push
-        - pull_request
-        - tag
-
-  - name: docker-publish
-    image: plugins/docker
-    settings:
-      build_args:
-        - SERVERCORE_VERSION=1909
-        - ARCH=amd64
-        - VERSION=${DRONE_TAG}
-      context: package/windows
-      custom_dns: 1.1.1.1
-      dockerfile: package/windows/Dockerfile
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: rancher/fluentd
-      tag: ${DRONE_TAG}-windows-1909
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - tag
-      ref:
-        - refs/heads/master
-        - refs/tags/*
-
-  - name: slack_notify
-    image: plugins/slack
-    settings:
-      template: "Build {{build.link}} failed to publish an image/artifact.\n"
-      username: Drone_Publish
-      webhook:
-        from_secret: slack_webhook
-    when:
-      event:
-        exclude:
-          - pull_request
-      instance:
-        - drone-publish.rancher.io
-      status:
-        - failure
-
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-      - promote
 ---
 kind: pipeline
 name: windows-2004
@@ -296,7 +144,7 @@ steps:
     image: luthermonson/drone-git:windows-2004-amd64
   - name: build
     pull: always
-    image: rancher/dapper:v0.5.4
+    image: rancher/dapper:v0.5.6
     commands:
       - dapper.exe -f Dockerfile-windows.dapper -d ci
     volumes:
@@ -378,7 +226,7 @@ steps:
     image: luthermonson/drone-git:windows-20H2-amd64
   - name: build
     pull: always
-    image: rancher/dapper:v0.5.4
+    image: rancher/dapper:v0.5.6
     commands:
       - dapper.exe -f Dockerfile-windows.dapper -d ci
     volumes:
@@ -484,7 +332,5 @@ trigger:
 depends_on:
 - linux-amd64
 - windows-1809
-- windows-1903
-- windows-1909
 - windows-2004
 - windows-20H2

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,11 +1,11 @@
-FROM rancher/golang:1.14-windowsservercore
+FROM rancher/golang:1.16-windowsservercore
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN pushd c:\; \
-    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/19.03.14/docker.exe'; \
+    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/20.10.5/docker.exe'; \
     \
     Write-Host ('Downloading docker from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -17,7 +17,7 @@ RUN pushd c:\; \
     popd;
 
 RUN pushd c:\; \
-    $URL = 'https://github.com/golangci/golangci-lint/releases/download/v1.33.0/golangci-lint-1.33.0-windows-amd64.zip'; \
+    $URL = 'https://github.com/golangci/golangci-lint/releases/download/v1.41.1/golangci-lint-1.41.1-windows-amd64.zip'; \
     \
     Write-Host ('Downloading golangci from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -30,14 +30,14 @@ RUN pushd c:\; \
     Remove-Item -Force -Recurse -Path c:\golangci-lint.zip; \
     \
     Write-Host 'Updating PATH ...'; \
-    [Environment]::SetEnvironmentVariable('PATH', ('c:\golangci-lint-1.33.0-windows-amd64\;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine); \
+    [Environment]::SetEnvironmentVariable('PATH', ('c:\golangci-lint-1.41.1-windows-amd64\;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine); \
     \
     Write-Host 'Complete.'; \
     popd;
 
 # upgrade git
 RUN pushd c:\; \
-    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.29.2.windows.3/MinGit-2.29.2.3-64-bit.zip'; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.32.0.windows.1/MinGit-2.32.0-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 # FROM arm=armhf/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -12,18 +12,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/fluentd:{{build.tag}}-windows-1903
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1903
-  -
-    image: rancher/fluentd:{{build.tag}}-windows-1909
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1909
-  -
     image: rancher/fluentd:{{build.tag}}-windows-2004
     platform:
       architecture: amd64

--- a/package/windows/Dockerfile
+++ b/package/windows/Dockerfile
@@ -1,29 +1,39 @@
 ARG SERVERCORE_VERSION
-
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
 
-SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# Download base ruby with devkit
+RUN powershell [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.3-1/rubyinstaller-devkit-2.7.3-1-x64.exe -Outfile rubyinstaller.exe
 
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
-    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+# Install base ruby and initialize devkit
+RUN (cmd /c rubyinstaller.exe /verysilent /log=install.log) || (powershell get-content c:/install.log)
+RUN powershell -NoLogo -Command $ErrorActionPreference = 'Stop'; $env:PATH = [Environment]::GetEnvironmentVariable('PATH','Machine'); \
+    powershell -NoLogo -Command $ErrorActionPreference = 'Stop'; $env:RUBYOPT = [Environment]::GetEnvironmentVariable('RUBYOPT','Machine')
 
-RUN choco install -y ruby --version 2.4.2.2 --params "'/InstallDir:C:\'"; \
-    choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby24\msys64'"
+# configure PATH for ruby and msys2
+RUN ruby --version
 
+# setup gemfile and gemrc files
 COPY Gemfile 'C:\fluentd\install\Gemfile'
 COPY Gemfile.lock 'C:\fluentd\install\Gemfile.lock'
 
-RUN refreshenv; \
-ridk install 2 3; \
-'gem: --no-document' | Out-File -Encoding UTF8 -NoNewline -Force -FilePath 'C:\ProgramData\gemrc'; \
-gem install bundler; \
-bundle config build.certstore_c --with-cflags="-Wno-attributes"; \
-bundle config build.yajl-ruby --with-cflags="-Wno-attributes"; \
-bundle config build.oj --with-cflags="-Wno-attributes"; \
-bundle install --gemfile='C:\fluentd\install\Gemfile'; \
-gem sources --clear-all; \
-Remove-Item -Force C:\ruby24\lib\ruby\gems\2.4.0\cache\*.gem; \
-Remove-Item -Recurse -Force C:\ProgramData\chocolatey
+# install msys2
+RUN ridk install 1
+RUN ridk enable
+
+# install gem bundler and configure bundles
+RUN powershell -Command $ErrorActionPreference = 'Stop'; \
+    "[IO.File]::WriteAllLines('C:\ProgramData\gemrc', 'gem: --no-document')"; \
+    gem install bundler --no-doc; \
+    bundle config build.certstore_c --with-cflags="-Wno-attributes"; \
+    bundle config build.yajl-ruby --with-cflags="-Wno-attributes"; \
+    bundle config build.oj --with-cflags="-Wno-attributes"; \
+    bundle install --gemfile='C:\fluentd\install\Gemfile'; \
+    gem sources --clear-all
+
+# cleanup
+RUN powershell -NoLogo -Command $ErrorActionPreference = 'SilentlyContinue'; Remove-Item -Force C:\Ruby27-x64\lib\ruby\gems\2.7.0\cache\*.gem
+RUN powershell -NoLogo -Command $ErrorActionPreference = 'SilentlyContinue'; Remove-Item -Force C:\rubyinstaller.exe
 
 COPY upgrade-gems.ps1 'C:\fluentd\install\upgrade-gems.ps1'
 COPY fluent.conf 'C:\etc\fluent\fluent.conf'


### PR DESCRIPTION
bump versions:
dapper to 0.5.6
docker cli for windows to 20.10.5
golangci-lint for windows to 1.41.1
MinGit fir windows to 2.32.0
dapper dockerfile FROM source to ubuntu 20.04
ruby to 2.7.3.1

reworked `package/windows/Dockerfile` to actually build and unblock further dev work

remove windows 1903 and 1909 builds 

https://github.com/rancher/rancher/issues/33486