### PR TITLE
revert to debian

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -19,19 +19,28 @@
 # Note that fluentd is run with root permssion to allow access to
 # log files with root only access under /var/log/containers/*
 
-FROM alpine:3.14
+FROM debian:stable-20210816-slim
 
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY clean-apt /usr/bin
+COPY clean-install /usr/bin
 COPY Gemfile /Gemfile
 COPY Gemfile.lock /Gemfile.lock
 
-RUN apk update \
-    && apk add --no-cache ca-certificates ruby ruby-dev ruby-irb ruby-etc ruby-webrick build-base \
+RUN BUILD_DEPS="make ruby-dev build-essential autoconf automake libtool libsnappy-dev" \
+    && clean-install $BUILD_DEPS \
+                     ca-certificates \
+                     ruby \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install bundler \
-    && bundle install \
+    && CFLAGS=-Wno-error=format-overflow bundle install \
+    && apt-get purge -y --auto-remove \
+                     -o APT::AutoRemove::RecommendsImportant=false \
+                     $BUILD_DEPS \
+    && clean-apt \
     # Ensure fluent has enough file descriptors
     && ulimit -n 65536 \
-    && apk del build-base \
     && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test \
     # Remove file due to red herring: https://github.com/fluent/fluentd/issues/3374#issuecomment-840916184
     && rm -f /usr/lib/ruby/gems/2.7.0/gems/http_parser.rb-0.6.0/Gemfile.lock

--- a/package/clean-apt
+++ b/package/clean-apt
@@ -14,10 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# These steps must be executed once the host /var and /lib volumes have
-# been mounted, and therefore cannot be done in the docker build stage.
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
 
-# For systems without journald
-mkdir -p /var/log/journal
+set -o errexit
 
-exec /usr/local/bin/fluentd $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*
+

--- a/package/clean-install
+++ b/package/clean-install
@@ -14,10 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# These steps must be executed once the host /var and /lib volumes have
-# been mounted, and therefore cannot be done in the docker build stage.
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
 
-# For systems without journald
-mkdir -p /var/log/journal
+set -o errexit
 
-exec /usr/local/bin/fluentd $@
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+clean-apt
+


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34548

# PROBLEM
the ruby `multi-json` gem does not work on alpine, this cascaded up  to the es plugin causing writes to fail

# SOLUTION
reverted the image back to debian

# TESTING
reproduced the issue in the ticket, I build this image locally and manually changed the ds image to mine.  The logs started flowing to es and I saw no notable errors.