### PR TITLE
remove windows 2004 sac, bump versions, switch to SLES from Ubuntu for dapper

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.5.6
+  image: rancher/dapper:v0.5.7
   commands:
   - dapper ci
   privileged: true
@@ -22,7 +22,7 @@ steps:
     - tag
 
 - name: docker-publish
-  image: rancher/dapper:v0.5.6
+  image: rancher/dapper:v0.5.7
   commands:
     - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     - docker image tag "rancher/fluentd:${DRONE_TAG}" "rancher/fluentd:${DRONE_TAG}-linux-amd64"
@@ -66,7 +66,7 @@ platform:
 steps:
   - name: build
     pull: always
-    image: rancher/dapper:v0.5.6
+    image: rancher/dapper:v0.5.7
     commands:
       - dapper.exe -f Dockerfile-windows.dapper -d ci
     volumes:
@@ -131,90 +131,6 @@ trigger:
       - promote
 ---
 kind: pipeline
-name: windows-2004
-
-platform:
-  os: windows
-  arch: amd64
-  version: 2004
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: rancher/drone-images:git-2004
-    settings:
-      depth: 20
-  - name: build
-    pull: always
-    image: rancher/dapper:v0.5.6
-    commands:
-      - dapper.exe -f Dockerfile-windows.dapper -d ci
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - push
-        - pull_request
-        - tag
-
-  - name: docker-publish
-    image: rancher/drone-images:docker-2004
-    settings:
-      build_args:
-        - SERVERCORE_VERSION=2004
-        - ARCH=amd64
-        - VERSION=${DRONE_TAG}
-      context: package/windows
-      custom_dns: 1.1.1.1
-      dockerfile: package/windows/Dockerfile
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: rancher/fluentd
-      tag: ${DRONE_TAG}-windows-2004
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - tag
-      ref:
-        - refs/heads/master
-        - refs/tags/*
-
-  - name: slack_notify
-    image: plugins/slack
-    settings:
-      template: "Build {{build.link}} failed to publish an image/artifact.\n"
-      username: Drone_Publish
-      webhook:
-        from_secret: slack_webhook
-    when:
-      event:
-        exclude:
-          - pull_request
-      instance:
-        - drone-publish.rancher.io
-      status:
-        - failure
-
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-      - promote
-
----
-kind: pipeline
 name: windows-20H2
 
 platform:
@@ -233,7 +149,7 @@ steps:
       depth: 20
   - name: build
     pull: always
-    image: rancher/dapper:v0.5.6
+    image: rancher/dapper:v0.5.7
     commands:
       - dapper.exe -f Dockerfile-windows.dapper -d ci
     volumes:
@@ -339,5 +255,4 @@ trigger:
 depends_on:
 - linux-amd64
 - windows-1809
-- windows-2004
 - windows-20H2

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -5,7 +5,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN pushd c:\; \
-    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/20.10.5/docker.exe'; \
+    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/20.10.9/docker.exe'; \
     \
     Write-Host ('Downloading docker from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -17,7 +17,7 @@ RUN pushd c:\; \
     popd;
 
 RUN pushd c:\; \
-    $URL = 'https://github.com/golangci/golangci-lint/releases/download/v1.41.1/golangci-lint-1.41.1-windows-amd64.zip'; \
+    $URL = 'https://github.com/golangci/golangci-lint/releases/download/v1.43.0/golangci-lint-1.43.0-windows-amd64.zip'; \
     \
     Write-Host ('Downloading golangci from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -30,14 +30,14 @@ RUN pushd c:\; \
     Remove-Item -Force -Recurse -Path c:\golangci-lint.zip; \
     \
     Write-Host 'Updating PATH ...'; \
-    [Environment]::SetEnvironmentVariable('PATH', ('c:\golangci-lint-1.41.1-windows-amd64\;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine); \
+    [Environment]::SetEnvironmentVariable('PATH', ('c:\golangci-lint-1.43.0-windows-amd64\;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine); \
     \
     Write-Host 'Complete.'; \
     popd;
 
 # upgrade git
 RUN pushd c:\; \
-    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.32.0.windows.1/MinGit-2.32.0-64-bit.zip'; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.33.1.windows.1/MinGit-2.33.1-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,26 +1,28 @@
-FROM ubuntu:20.04
-# FROM arm=armhf/ubuntu:16.04
+FROM registry.suse.com/suse/sle15:15.3
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper install -y -f docker
+
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+RUN curl -sLf https://storage.googleapis.com/golang/go1.16.9.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
 
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
+RUN if [ "${ARCH}" == "amd64" ]; then \
+        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.43.0; \
+        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh; \
+    fi
 
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+# workaround for https://bugzilla.suse.com/show_bug.cgi?id=1183043
+RUN if [ "${ARCH}" == "arm64" ]; then \
+        zypper -n install binutils-gold ; \
+    fi
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH
 ENV DAPPER_SOURCE /go/src/github.com/rancher/fluentd/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -12,12 +12,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/fluentd:{{build.tag}}-windows-2004
-    platform:
-      architecture: amd64
-      os: windows
-      version: 2004
-  -
     image: rancher/fluentd:{{build.tag}}-windows-20H2
     platform:
       architecture: amd64

--- a/scripts/windows/package.ps1
+++ b/scripts/windows/package.ps1
@@ -5,7 +5,7 @@ Invoke-Expression -Command "$PSScriptRoot\get-image.ps1"
 
 $DIR_PATH = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $SRC_PATH = (Resolve-Path "$DIR_PATH\..\..").Path
-cd $SRC_PATH\package\windows
+Set-Location -Path $SRC_PATH\package\windows
 
 $ARCH = $env:ARCH
 $TAG = $env:TAG
@@ -32,4 +32,4 @@ if ($RELEASE_ID -eq $HOST_RELEASE_ID) {
 
 $DIST_PATH = "$SRC_PATH\dist\"
 $null = New-Item -Type Directory -Path $DIST_PATH -ErrorAction Ignore
-echo $IMAGE > "$DIST_PATH\images"
+Write-Output $IMAGE > "$DIST_PATH\images"


### PR DESCRIPTION
- remove Windows Server 2004 SAC from drone build steps and manifest template
- fix a few aliases in package.ps1 to use full cmdlet
- bump to dapper 0.5.7
- bump to go1.16.9 in Dockerfile.dapper and remove rancher/trash
- switch dapper dockerfile from using ubuntu to sles
- after switching to sles, use docker installed from zypper instead of the antiquated docker-cli builds